### PR TITLE
add old fingerprint implementation, ability to disable face unlock for security reasons

### DIFF
--- a/app/src/main/java/com/beautycoder/applicationlockscreenexample/MainActivity.java
+++ b/app/src/main/java/com/beautycoder/applicationlockscreenexample/MainActivity.java
@@ -3,6 +3,7 @@ package com.beautycoder.applicationlockscreenexample;
 import androidx.lifecycle.Observer;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
@@ -10,7 +11,6 @@ import android.widget.Toast;
 import com.beautycoder.pflockscreen.PFFLockScreenConfiguration;
 import com.beautycoder.pflockscreen.fragments.PFLockScreenFragment;
 import com.beautycoder.pflockscreen.security.PFResult;
-import com.beautycoder.pflockscreen.security.PFSecurityManager;
 import com.beautycoder.pflockscreen.viewmodels.PFPinCodeViewModel;
 
 public class MainActivity extends AppCompatActivity {
@@ -90,6 +90,7 @@ public class MainActivity extends AppCompatActivity {
                 .setNewCodeValidation(true)
                 .setNewCodeValidationTitle("Please input code again")
                 .setAutoShowBiometric(true)
+                .setCanUseFaceUnlock(false)
                 .setUseBiometric(true);
         final PFLockScreenFragment fragment = new PFLockScreenFragment();
 

--- a/pflockscreen/build.gradle
+++ b/pflockscreen/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 
-group='com.github.thealeksandr'
+group = 'com.github.thealeksandr'
 
 final def lifecycle_version = "2.0.0"
 
@@ -13,7 +13,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1
-        versionName "1.0.0-beta9"
+        versionName "1.0.0-beta10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }

--- a/pflockscreen/src/main/java/com/beautycoder/pflockscreen/PFFLockScreenConfiguration.java
+++ b/pflockscreen/src/main/java/com/beautycoder/pflockscreen/PFFLockScreenConfiguration.java
@@ -17,6 +17,7 @@ public class PFFLockScreenConfiguration implements Serializable {
     private String mLeftButton = "";
     private String mNextButton = "";
     private boolean mUseBiometric = false;
+    private boolean mCanUseFaceUnlock = true;
     private boolean mAutoShowBiometric = false;
     private int mBiometricBackground = -1;
     private String mTitle = "";
@@ -33,6 +34,7 @@ public class PFFLockScreenConfiguration implements Serializable {
         mLeftButton = builder.mLeftButton;
         mNextButton = builder.mNextButton;
         mUseBiometric = builder.mUseBiometric;
+        mCanUseFaceUnlock = builder.mUseFaceUnlock;
         mAutoShowBiometric = builder.mAutoShowBiometric;
         mBiometricBackground = builder.mBiometricBackground;
         mTitle = builder.mTitle;
@@ -56,6 +58,10 @@ public class PFFLockScreenConfiguration implements Serializable {
 
     public boolean isUseBiometric() {
         return mUseBiometric;
+    }
+
+    public boolean isCanUseFaceUnlock() {
+        return mCanUseFaceUnlock;
     }
 
     public boolean isAutoShowBiometric() {
@@ -94,7 +100,7 @@ public class PFFLockScreenConfiguration implements Serializable {
         return mNewCodeValidationTitle;
     }
 
-    public boolean goNextWhenCodeCompleted(){
+    public boolean goNextWhenCodeCompleted() {
         return mGoNextWhenCodeCompleted;
     }
 
@@ -119,6 +125,7 @@ public class PFFLockScreenConfiguration implements Serializable {
         private boolean mNewCodeValidation = false;
         private String mNewCodeValidationTitle = "";
         private boolean mGoNextWhenCodeCompleted = true;
+        private boolean mUseFaceUnlock = true;
 
         public Builder(Context context) {
             mTitle = context.getResources().getString(R.string.lock_screen_title_pf);
@@ -151,6 +158,11 @@ public class PFFLockScreenConfiguration implements Serializable {
 
         public Builder setAutoShowBiometric(boolean autoShowBiometric) {
             mAutoShowBiometric = autoShowBiometric;
+            return this;
+        }
+
+        public Builder setCanUseFaceUnlock(boolean useFaceUnlock) {
+            mUseFaceUnlock = useFaceUnlock;
             return this;
         }
 

--- a/pflockscreen/src/main/java/com/beautycoder/pflockscreen/fragments/PFFingerprintAuthDialogFragment.java
+++ b/pflockscreen/src/main/java/com/beautycoder/pflockscreen/fragments/PFFingerprintAuthDialogFragment.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.beautycoder.pflockscreen.fragments;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.RequiresApi;
+import androidx.fragment.app.DialogFragment;
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.beautycoder.pflockscreen.R;
+
+/**
+ * A dialog which uses fingerprint APIs to authenticate the user, and falls back to password
+ * authentication if fingerprint is not available.
+ */
+@RequiresApi(api = Build.VERSION_CODES.M)
+public class PFFingerprintAuthDialogFragment extends DialogFragment {
+
+    private Button mCancelButton;
+    private View mFingerprintContent;
+
+    private Stage mStage = Stage.FINGERPRINT;
+
+    private FingerprintManagerCompat.CryptoObject mCryptoObject;
+
+    private PFFingerprintUIHelper mFingerprintCallback;
+
+    private Context mContext;
+
+    private PFFingerprintAuthListener mAuthListener;
+
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Do not create a new Fragment when the Activity is re-created such as orientation changes.
+        setRetainInstance(true);
+        setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        getDialog().setTitle(getString(R.string.sign_in_pf));
+        View v = inflater.inflate(R.layout.view_pf_fingerprint_dialog_container, container,
+                false);
+        mCancelButton = v.findViewById(R.id.cancel_button);
+        mCancelButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                dismiss();
+            }
+        });
+
+        mFingerprintContent = v.findViewById(R.id.fingerprint_container);
+
+
+        FingerprintManagerCompat manager = FingerprintManagerCompat.from(getContext());
+        mFingerprintCallback = new PFFingerprintUIHelper(manager,
+                (ImageView) v.findViewById(R.id.fingerprint_icon),
+                (TextView) v.findViewById(R.id.fingerprint_status),
+                mAuthListener);
+        updateStage();
+        return v;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mStage == Stage.FINGERPRINT) {
+            mFingerprintCallback.startListening(mCryptoObject);
+        }
+    }
+
+    public void setStage(Stage stage) {
+        mStage = stage;
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mFingerprintCallback.stopListening();
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        mContext = context;
+    }
+
+    /**
+     * Sets the crypto object to be passed in when authenticating with fingerprint.
+     */
+    /*public void setCryptoObject(FingerprintManagerCompat.CryptoObject cryptoObject) {
+        mCryptoObject = cryptoObject;
+    }*/
+    private void updateStage() {
+        switch (mStage) {
+            case FINGERPRINT:
+                mCancelButton.setText(R.string.cancel_pf);
+                mFingerprintContent.setVisibility(View.VISIBLE);
+                break;
+        }
+    }
+
+
+    public void setAuthListener(PFFingerprintAuthListener authListener) {
+        mAuthListener = authListener;
+    }
+
+    /**
+     * Enumeration to indicate which authentication method the user is trying to authenticate with.
+     */
+    public enum Stage {
+        FINGERPRINT
+    }
+}

--- a/pflockscreen/src/main/java/com/beautycoder/pflockscreen/fragments/PFFingerprintUIHelper.java
+++ b/pflockscreen/src/main/java/com/beautycoder/pflockscreen/fragments/PFFingerprintUIHelper.java
@@ -1,0 +1,131 @@
+package com.beautycoder.pflockscreen.fragments;
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
+import androidx.core.os.CancellationSignal;
+
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.beautycoder.pflockscreen.R;
+
+
+/**
+ * Created by aleksandr on 2018/02/10.
+ */
+
+@RequiresApi(api = Build.VERSION_CODES.M)
+public class PFFingerprintUIHelper extends FingerprintManagerCompat.AuthenticationCallback {
+
+    private static final long ERROR_TIMEOUT_MILLIS = 1600;
+    private static final long SUCCESS_DELAY_MILLIS = 200;
+
+    private final FingerprintManagerCompat mFingerprintManager;
+    private final ImageView mIcon;
+    private final TextView mErrorTextView;
+    private final PFFingerprintAuthListener mCallback;
+    private CancellationSignal mCancellationSignal;
+
+    private boolean mSelfCancelled;
+
+    public PFFingerprintUIHelper(FingerprintManagerCompat fingerprintManager,
+                                 ImageView icon, TextView errorTextView,
+                                 PFFingerprintAuthListener callback) {
+        super();
+        mFingerprintManager = fingerprintManager;
+        mIcon = icon;
+        mErrorTextView = errorTextView;
+        mCallback = callback;
+    }
+
+    public boolean isFingerprintAuthAvailable() {
+        // The line below prevents the false positive inspection from Android Studio
+        // noinspection ResourceType
+        return mFingerprintManager.isHardwareDetected()
+                && mFingerprintManager.hasEnrolledFingerprints();
+    }
+
+    public void startListening(FingerprintManagerCompat.CryptoObject cryptoObject) {
+        if (!isFingerprintAuthAvailable()) {
+            return;
+        }
+        mCancellationSignal = new CancellationSignal();
+        mSelfCancelled = false;
+        // The line below prevents the false positive inspection from Android Studio
+        // noinspection ResourceType
+        mFingerprintManager.authenticate(
+                cryptoObject, 0, mCancellationSignal, this, null);
+        mIcon.setImageResource(R.drawable.ic_fp_40px_pf);
+    }
+
+    public void stopListening() {
+        if (mCancellationSignal != null) {
+            mSelfCancelled = true;
+            mCancellationSignal.cancel();
+            mCancellationSignal = null;
+        }
+    }
+
+    @Override
+    public void onAuthenticationError(int errMsgId, CharSequence errString) {
+        if (!mSelfCancelled) {
+            showError(errString);
+            mIcon.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mCallback.onError();
+                }
+            }, ERROR_TIMEOUT_MILLIS);
+        }
+    }
+
+    @Override
+    public void onAuthenticationHelp(int helpMsgId, CharSequence helpString) {
+        showError(helpString);
+    }
+
+    @Override
+    public void onAuthenticationFailed() {
+        showError(mIcon.getResources().getString(
+                R.string.fingerprint_not_recognized_pf));
+    }
+
+    @Override
+    public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
+        mErrorTextView.removeCallbacks(mResetErrorTextRunnable);
+        mIcon.setImageResource(R.drawable.ic_fingerprint_success_pf);
+        mErrorTextView.setTextColor(
+                mErrorTextView.getResources().getColor(R.color.success_color, null));
+        mErrorTextView.setText(
+                mErrorTextView.getResources().getString(R.string.fingerprint_success_pf));
+        mIcon.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                mCallback.onAuthenticated();
+            }
+        }, SUCCESS_DELAY_MILLIS);
+    }
+
+    private void showError(CharSequence error) {
+        mIcon.setImageResource(R.drawable.ic_fingerprint_error_pf);
+        mErrorTextView.setText(error);
+        mErrorTextView.setTextColor(
+                mErrorTextView.getResources().getColor(R.color.warning_color, null));
+        mErrorTextView.removeCallbacks(mResetErrorTextRunnable);
+        mErrorTextView.postDelayed(mResetErrorTextRunnable, ERROR_TIMEOUT_MILLIS);
+    }
+
+    private Runnable mResetErrorTextRunnable = new Runnable() {
+        @Override
+        public void run() {
+            mErrorTextView.setTextColor(
+                    mErrorTextView.getResources().getColor(R.color.hint_color, null));
+            mErrorTextView.setText(
+                    mErrorTextView.getResources().getString(R.string.fingerprint_hint_pf));
+            mIcon.setImageResource(R.drawable.ic_fp_40px_pf);
+        }
+    };
+
+}

--- a/pflockscreen/src/main/res/values-de/strings.xml
+++ b/pflockscreen/src/main/res/values-de/strings.xml
@@ -11,6 +11,8 @@
     <string name="no_fingerprints_message_pf">Keine biometrischen Daten gefunden. Bitte fügen
         Sie in den Einstellungen welche hinzu.</string>
     <string name="no_fingerprints_title_pf">Keine biometrischen Daten gefunden</string>
+    <string name="fingerprint_not_recognized_pf">Fingerabdruck nicht erkannt. Bitte nochmal versuchen</string>
+    <string name="fingerprint_success_pf">Fingerabdruck erkannt</string>
 
     <string name="fingerprint_description_pf">Fingerabdruck bestätigen</string>
     <string name="fingerprint_hint_pf">Sensor berühren</string>

--- a/pflockscreen/src/main/res/values/strings.xml
+++ b/pflockscreen/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="settings_pf">Settings</string>
     <string name="no_fingerprints_message_pf">No biometric data found. Please add fingerprints or face recognition in the settings if you want to use this authorization method."</string>
     <string name="no_fingerprints_title_pf">"No biometric data found"</string>
+    <string name="fingerprint_not_recognized_pf">Fingerprint not recognized. Try again</string>
+    <string name="fingerprint_success_pf">Fingerprint recognized</string>
 
     <string name="fingerprint_description_pf">Confirm fingerprint to continue</string>
     <string name="fingerprint_hint_pf">Touch sensor</string>


### PR DESCRIPTION
with the new androidx.biometric implementation face unlock cannot be disabled on demand
reactivated old implementation,
the old implementation can be enabled using PFFLockScreenConfiguration.Builder. setCanUseFaceUnlock(false)
